### PR TITLE
docs: add renovate logs link to dependency dashboards

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,6 +18,7 @@
   "dependencyDashboardTitle": "Dependencies Dashboard (Renovate Bot)",
   "dependencyDashboardHeader": "Uses https://github.com/bettermarks/renovate-config#default  \nPR that have automerge enabled [might be approved automatically](https://github.com/bettermarks/approve-dependency-pr#readme)",
   "dependencyDashboardOSVVulnerabilitySummary": "none",
+  "dependencyDashboardFooter": "The renovate logs can be found at <https://developer.mend.io/github/bettermarks>",
   "osvVulnerabilityAlerts": false,
   "vulnerabilityAlerts": {
     "labels": ["security"],


### PR DESCRIPTION
The `dependencyDashboardFooter` option defaults to `null` so we don't loose any information

Since it's part of the template, we can not link to the logs of the repository, but this could be overridden in each repositories config if needed.

https://docs.renovatebot.com/configuration-options/#dependencydashboardfooter