### PR TITLE
fix: restore checkbox to trigger a renovate scan in dependency dashboard

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,7 +18,7 @@
   "dependencyDashboardTitle": "Dependencies Dashboard (Renovate Bot)",
   "dependencyDashboardHeader": "Uses https://github.com/bettermarks/renovate-config#default  \nPR that have automerge enabled [might be approved automatically](https://github.com/bettermarks/approve-dependency-pr#readme)",
   "dependencyDashboardOSVVulnerabilitySummary": "none",
-  "dependencyDashboardFooter": "The renovate logs can be found at <https://developer.mend.io/github/bettermarks>",
+  "dependencyDashboardFooter": "- [ ] <!-- manual job -->Check this box to trigger a request for Renovate to run again on this repository\n- The renovate logs can be found at <https://developer.mend.io/github/bettermarks>",
   "osvVulnerabilityAlerts": false,
   "vulnerabilityAlerts": {
     "labels": ["security"],


### PR DESCRIPTION
the docs are not correct, using the footer ectualle overrides the default footer, which offer a checkbox to trigger a renovate run.

I copied the following from the dashboard description markdown from a non bettermarks repository: 
```
- [ ] <!-- manual job -->Check this box to trigger a request for Renovate to run again on this repository
```
so this will restore it.

https://github.com/renovatebot/renovate/discussions/27175#discussioncomment-9224803
