### PR TITLE
fix: link to mend dashboard from dependency dashboards

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,7 +18,7 @@
   "dependencyDashboardTitle": "Dependencies Dashboard (Renovate Bot)",
   "dependencyDashboardHeader": "Uses https://github.com/bettermarks/renovate-config#default  \nPR that have automerge enabled [might be approved automatically](https://github.com/bettermarks/approve-dependency-pr#readme)",
   "dependencyDashboardOSVVulnerabilitySummary": "none",
-  "dependencyDashboardFooter": "- [ ] <!-- manual job -->Check this box to trigger a request for Renovate to run again on this repository\n- The renovate logs can be found at <https://developer.mend.io/github/bettermarks>",
+  "dependencyDashboardFooter": "- [ ] <!-- manual job -->Check this box to trigger a request for Renovate to run again on this repository\n- The renovate logs can be found at <https://developer.mend.io>",
   "osvVulnerabilityAlerts": false,
   "vulnerabilityAlerts": {
     "labels": ["security"],


### PR DESCRIPTION
Since this config can not know what repository it is used it, I wrongly assumed I could drop only the repository part of the path.  But this only works if the user is already logged in to the dashboard. Otherwise it results in a 500 error page.

By linking to the same host without any path, if you are not logged in you are asked to login, and have to find the repository logs yourself. Or use the link from any of the PRs.
