### PR TITLE
fix(python): pip-compile config

### DIFF
--- a/python.json
+++ b/python.json
@@ -4,11 +4,8 @@
     "github>bettermarks/renovate-config"
   ],
   "dependencyDashboardHeader": "Uses https://github.com/bettermarks/renovate-config#python  \nPR that have automerge enabled [might be approved automatically](https://github.com/bettermarks/approve-dependency-pr#readme)",
-  "constraints": {
-    "python": "==3.8"
-  },
   "pip-compile": {
-    "fileMatch": ["(^|/)requirements(-.*)?\\.in$"]
+    "fileMatch": ["(^|/)requirements(-.*)?\\.txt$"]
   },
   "pip_requirements": {
     "enabled": false


### PR DESCRIPTION
Following experiences with https://github.com/bettermarks/bm-nlp-validator, `fileMatch` for `pip-compile` needs to match the `*.txt` files, not the `*.in` files. See docs: https://docs.renovatebot.com/modules/manager/pip-compile/#non-configured-filematch

Also dropped Python version constraint, since it's different for every project anyway, and `3.8` should definitely not be a default anymore.

**How has this been tested?**

See e.g. https://github.com/bettermarks/bm-nlp-validator/pull/226 resulting from correct config there.
