### PR TITLE
perf: changed schedule and migrated configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,16 +135,14 @@ and it configures the following:
 
 ##### Rules for [reducing noise](https://docs.renovatebot.com/noise-reduction/):
 
-Only automatically create one PR at a time and only create/update PRs [outside of office hours](https://docs.renovatebot.com/presets-schedule/#schedulenonofficehours). 
+Only automatically create one PR at a time and only create/update PRs in the morning and evening,
+which is related to the start and end of working days.
 Create the PR right away when checks done by renovate (like [`npm:unpublishSafe`](https://docs.renovatebot.com/presets-npm/#npmunpublishsafe)) pass 
 and only up to six times per hour (every 10 min).
 All major version bumps need to be triggered manually from the dependency dashboard.
 
 ```json
 {
-  "extends": [
-    "schedule:nonOfficeHours"
-  ],
   "internalChecksFilter": "strict",
   "prConcurrentLimit": 1,
   "prHourlyLimit": 6,
@@ -154,7 +152,8 @@ All major version bumps need to be triggered manually from the dependency dashbo
       "matchUpdateTypes": ["major"],
       "dependencyDashboardApproval": true
     }
-  ]
+  ],
+  "schedule": ["* 7-9,18-19 * * 1-5"]
 }
 ```
 

--- a/default.json
+++ b/default.json
@@ -7,9 +7,8 @@
     ":prImmediately",
     ":separateMajorReleases",
     ":separateMultipleMajorReleases",
-    "schedule:nonOfficeHours",
     "preview:dockerVersions",
-    "regexManagers:dockerfileVersions"
+    "customManagers:dockerfileVersions"
   ],
   "internalChecksFilter": "strict",
   "prConcurrentLimit": 1,
@@ -27,9 +26,7 @@
   },
   "addLabels": ["dependencies"],
   "packageRules": [
-    {
-      "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true
-    }
-  ]
+    {"matchUpdateTypes": ["major"], "dependencyDashboardApproval": true}
+  ],
+  "schedule": ["* 7-9,18-19 * * 1-5"]
 }

--- a/javascript.json
+++ b/javascript.json
@@ -8,26 +8,16 @@
   ],
   "dependencyDashboardHeader": "Uses https://github.com/bettermarks/renovate-config#javascript  \nPR that have automerge enabled [might be approved automatically](https://github.com/bettermarks/approve-dependency-pr#readme)",
   "packageRules": [
-    {
-      "matchUpdateTypes": ["pin"],
-      "prPriority": 10,
-      "automerge": true
-    },
+    {"matchUpdateTypes": ["pin"], "prPriority": 10, "automerge": true},
     {
       "matchPackageNames": ["node", "@types/node"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },
+    {"matchPackageNames": ["node"], "rangeStrategy": "replace"},
+    {"matchDepTypes": ["resolutions"], "rangeStrategy": "auto"},
     {
-      "matchPackageNames": ["node"],
-      "rangeStrategy": "replace"
-    },
-    {
-      "matchDepTypes": ["resolutions"],
-      "rangeStrategy": "auto"
-    },
-    {
-      "matchPackagePatterns": ["^@bettermarks\/.*", "^bm-.*"],
+      "matchPackageNames": ["/^@bettermarks/.*/", "/^bm-.*/"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "prPriority": 5,
       "minimumReleaseAge": null,
@@ -40,11 +30,11 @@
       "prPriority": 2
     },
     {
-      "matchSourceUrlPrefixes": [
-        "https://github.com/aws",
-        "https://github.com/cdk8s-team",
-        "https://github.com/cdktf",
-        "https://github.com/hashicorp"
+      "matchSourceUrls": [
+        "https://github.com/aws{/,}**",
+        "https://github.com/cdk8s-team{/,}**",
+        "https://github.com/cdktf{/,}**",
+        "https://github.com/hashicorp{/,}**"
       ],
       "groupName": "js infrastructure packages",
       "minimumReleaseAge": null,
@@ -54,16 +44,12 @@
       "automerge": true
     },
     {
-      "matchManagers": [
-        "npm"
-      ],
-      "matchPackageNames": [
-        "@types/jest"
-      ],
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@types/jest"],
       "versioning": "jest"
     },
     {
-      "matchPackagePatterns": ["^@types\/.*"],
+      "matchPackageNames": ["/^@types/.*/"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "minimumReleaseAge": null,
       "prPriority": -5,


### PR DESCRIPTION
Since we are hibernating some services during the night, we decided to also limit the creation of update PRs to time frames closer to working hours. This can of course be changed per repository.

Since the config validation revealed some available migrations, those have been applied.
