### PR TITLE
perf: tweak schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ All major version bumps need to be triggered manually from the dependency dashbo
       "dependencyDashboardApproval": true
     }
   ],
-  "schedule": ["* 7-9,18-19 * * 1-5"]
+  "schedule": ["* 8,18-19 * * 1-5"]
 }
 ```
 

--- a/default.json
+++ b/default.json
@@ -28,5 +28,5 @@
   "packageRules": [
     {"matchUpdateTypes": ["major"], "dependencyDashboardApproval": true}
   ],
-  "schedule": ["* 7-9,18-19 * * 1-5"]
+  "schedule": ["* 8,18-19 * * 1-5"]
 }


### PR DESCRIPTION
- it starts to early in the morning, leading to failed checks
- it reaches to far into our working hours (we are at UTC+1)

Now it only provides update in the hour before our dailies, and in the evening in the last two hours before the segments are hibernates
