### PR TITLE
perf: update javascript schedule for dev hibernation

### DIFF
--- a/javascript.json
+++ b/javascript.json
@@ -40,7 +40,7 @@
       "minimumReleaseAge": null,
       "prPriority": 1,
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "schedule": ["before 4am on Monday"],
+      "schedule": ["before 10am on Monday"],
       "automerge": true
     },
     {


### PR DESCRIPTION
The current schedule ("before 4am on Monday") doesn't work well for `bm-backend`, e.g.:

https://github.com/bettermarks/bm-backend/actions/runs/13755525789

The update was automerged around 2:30am and the following version bump failed due to hibernated dev clusters.
