### PR TITLE
chore: drop secrets from init workflow

### DIFF
--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -15,10 +15,6 @@ on:
         description: "Is the repository using python dependencies? (experimental!)"
         default: false
         type: boolean
-      secrets:
-        description: "Is the repository using private npm packages in the `@bettermarks/` scope?"
-        type: boolean
-        default: false
       automerge:
         description: "Should some dependency updates be merged a human review? Leave the field empty if you are not sure!"
         default: ""

--- a/init.js
+++ b/init.js
@@ -10,7 +10,6 @@ const config = {
   extends: [
     `github>bettermarks/renovate-config${inputs.javascript ? ':javascript' : ''}`,
     inputs.python ? 'github>bettermarks/renovate-config:python' : '',
-    inputs.secrets ? 'github>bettermarks/renovate-secrets' : '',
     inputs.automerge,
   ].filter(Boolean)
 };


### PR DESCRIPTION
secrets from shared configs are no longer supported, so we should also not ask for the option
when using the init workflow to start using renovate.

https://docs.renovatebot.com/mend-hosted/migrating-secrets/
