### PR TITLE
chore: use latest image with fixed version

### DIFF
--- a/validator/action.yml
+++ b/validator/action.yml
@@ -7,7 +7,7 @@ inputs:
 
 runs:
   using: docker
-  image: docker://renovate/renovate:slim
+  image: docker://renovate/renovate:40.13
   # https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action#accessing-files-created-by-a-container-action
   # When a container action runs, it will automatically map the default working directory (GITHUB_WORKSPACE)
   # on the runner with the /github/workspace directory on the container.


### PR DESCRIPTION
* Image `docker://renovate/renovate:slim` coming from this repository (https://github.com/renovatebot/docker-renovate) is not upto date as it was already archived on 9th February.
* I picked the latest image from https://hub.docker.com/r/renovate/renovate/tags and pinned it to specific version.