### PR TITLE
feat: use github actions custom version manager

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,7 +8,8 @@
     ":separateMajorReleases",
     ":separateMultipleMajorReleases",
     "preview:dockerVersions",
-    "customManagers:dockerfileVersions"
+    "customManagers:dockerfileVersions",
+    "customManagers:githubActionsVersions"
   ],
   "internalChecksFilter": "strict",
   "prConcurrentLimit": 1,


### PR DESCRIPTION
We've found this useful in many repositories to fix certain versions of tools but also get automatic updates. (such as for `uv` where we specify a specific version for the action to use (which is independent of the action itself).

Example usage in one of our private repositories.
```yaml
env:
  # renovate: datasource=github-tags depName=uv lookupName=astral-sh/uv
  UV_VERSION: 0.6.16
```

Rather than add this to each repo, it'd be nice to have it already configured like we do for the same syntax in dockerfiles