### PR TITLE
feat: python updates: require approval for minor update

### DIFF
--- a/python.json
+++ b/python.json
@@ -12,6 +12,14 @@
       "description": "Production dependencies",
       "matchFileNames": ["requirements.txt", "requirements.in"],
       "semanticCommitType": "fix"
+    },
+    {
+      "description": [
+        "Python's minor updates may be breaking so are actually major updates per semver."
+      ],
+      "matchDepNames": "python",
+      "matchUpdateTypes": "minor",
+      "dependencyDashboardApproval": true
     }
   ]
 }

--- a/python.json
+++ b/python.json
@@ -20,6 +20,16 @@
       "matchDepNames": "python",
       "matchUpdateTypes": "minor",
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": [
+        "Update patch versions of Python",
+        "works for both .python-version and docker versions.",
+        "Makes both patch and minor versions available so either can be chosen."
+      ],
+      "matchDepNames": "python",
+      "separateMinorPatch": true,
+      "separateMultipleMinor": true
     }
   ]
 }


### PR DESCRIPTION
Python doesn't follow semver, its minor versions contain deprecations and removals (i.e. breaking changes).

We ought to place them under the requiring approval section of the renovate dashboard [like we do](https://github.com/bettermarks/renovate-config/blob/0bb759f768c987134b354c0ac9016bb93d4b3bf6/default.json#L30) for other major updates.

Why now? Despite that it was a manual click that created the PR for our [recent GLU adventure](https://github.com/bettermarks/bm-glu/pull/2667) - it would also have been possible for renovate to have done that automatically. 

I also add `"separateMinorPatch": true, "separateMultipleMinor": true` so that we still automerge patch updates and don't start to miss them just because a new major version has come out.


**How has this been tested?**

In https://github.com/bettermarks/renovate-config-test-pip-compile/commit/434ebeb33277234c08c00c3c8102ac61bccb33ac 

In the [dashboard](https://github.com/bettermarks/renovate-config-test-pip-compile/issues/3#issue-1915995576) 

<img width="1886" height="654" alt="image" src="https://github.com/user-attachments/assets/8c7c0d8d-1687-428f-ac5e-9c35564afa79" />

