### PR TITLE
fix: inline  to configure registry mapping

### DIFF
--- a/javascript.json
+++ b/javascript.json
@@ -6,6 +6,7 @@
     ":maintainLockFilesMonthly"
   ],
   "dependencyDashboardHeader": "Uses https://github.com/bettermarks/renovate-config#javascript  \nPR that have automerge enabled [might be approved automatically](https://github.com/bettermarks/approve-dependency-pr#readme)",
+  "npmrc": "@bettermarks:registry=https://npm.pkg.github.com/\n@fortawesome:registry=https://npm.fontawesome.com/\n",
   "packageRules": [
     { "matchUpdateTypes": ["pin"], "prPriority": 10, "automerge": true },
     {


### PR DESCRIPTION
According to https://docs.renovatebot.com/getting-started/private-packages/#automatically-authenticate-for-npm-package-stored-in-private-github-npm-repository

Host rules are already configured at organization level on the mend-renovate platform.

This is required because of changes in pnpm 11.7 to private registry resolution. See update in mifro https://github.com/bettermarks/bm-mifro/pull/7751

I tested it by running renovate locally with and without the config and could reproduce the issue of missing mappings.
