### PR TITLE
fix: add k8s config extending javascript

### DIFF
--- a/.github/workflows/init.yml
+++ b/.github/workflows/init.yml
@@ -15,6 +15,10 @@ on:
         description: "Is the repository using python dependencies? (experimental!)"
         default: false
         type: boolean
+      k8s:
+        description: "Is the repository managing Kubernetes/CDK8s infrastructure in a k8s/ directory?"
+        default: false
+        type: boolean
       automerge:
         description: "Should some dependency updates be merged a human review? Leave the field empty if you are not sure!"
         default: ""

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
           - default.json
           - javascript.json
           - python.json
+          - k8s.json
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2 # required for running the local validate action in the next step

--- a/README.md
+++ b/README.md
@@ -225,6 +225,34 @@ Be aware that there are the config presets for [`config:js-app`](https://docs.re
 
 A very common thing is to add [`:autoMergePatch`](https://docs.renovatebot.com/presets-default/#automergepatch) to `extends`, but this needs to happen on the repository level, since we cannot be sure that test coverage is good enough in every repo. And since GitHub now offers the option to enable automerge per PR when it's ready, there might not even be a need for it.
 
+### k8s
+
+Extends the [javascript](#javascript) config with additional rules for repositories that manage Kubernetes/CDK8s infrastructure in a `k8s/` directory.
+
+```json
+{
+  "extends": ["github>bettermarks/renovate-config:k8s"]
+}
+```
+
+#### What it does
+
+It includes the following presets/configs:
+
+- the [javascript config](#javascript) from this repository
+
+and it configures the following:
+
+- Group JavaScript infrastructure-as-code packages from AWS, CDK8s, CDKTF and HashiCorp into a single PR,
+  schedule their updates on Monday mornings (8-12 Berlin time), enable automerge,
+  and assign them a priority of 1.
+- Label dependencies from `k8s/package.json` as `k8s`, use `chore` as the semantic commit type,
+  and enable automerge for them.
+- Allow major Node.js version updates in `k8s/.nvmrc` to be created without requiring
+  manual approval from the dependency dashboard.
+- Link to this section in the readme from the dependency dashboard,
+  mentioning that this config extends the javascript config and that PRs might be merged automatically.
+
 ### python
 
 **There is currently only [limited / "alpha level" support](https://github.com/renovatebot/renovate/blob/main/lib/modules/manager/pip-compile/readme.md) for python using `pip-compile`.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ you should not enable to automerge option.
 
 ## Presets
 
+| Project type                       | Preset to extend                                    |
+| ---------------------------------- | --------------------------------------------------- |
+| JS/TS repo without a `k8s/` folder | `github>bettermarks/renovate-config:javascript`     |
+| JS/TS repo with a `k8s/` folder    | `github>bettermarks/renovate-config:javascript-k8s` |
+| Python repo with a `k8s/` folder   | `github>bettermarks/renovate-config:python-k8s`     |
+| Any repo with only a `k8s/` folder | `github>bettermarks/renovate-config:k8s`            |
+
 ### default
 
 It contains only language independent defaults that we want to apply to **all** repositories.
@@ -182,9 +189,34 @@ Example: Running `pnpm install --no-frozen-lockfile` in order to restore the `pn
 }
 ```
 
+### npm-base
+
+Shared foundation for any preset that deals with npm packages. You usually do
+not extend this directly; use [javascript](#javascript), [k8s](#k8s) or one of the
+combined presets instead.
+
+```json
+{
+  "extends": ["github>bettermarks/renovate-config:npm-base"]
+}
+```
+
+#### What it does
+
+It includes the following presets:
+
+- the [default config](#default) from this repository
+- [`:pinAllExceptPeerDependencies`](https://docs.renovatebot.com/presets-default/#pinallexceptpeerdependencies)
+- [`:maintainLockFilesMonthly`](https://docs.renovatebot.com/presets-default/#maintainlockfilesmonthly)
+
+and it configures the following:
+
+- `npmrc` entries for the `@bettermarks` and `@fortawesome` scopes.
+- Group [`prettier`](https://github.com/prettier/prettier) updates into a single PR.
+
 ### javascript
 
-Adds some rules we generally apply in javascript related repositories.
+Adds rules we generally apply in JavaScript/TypeScript repositories.
 
 ```json
 {
@@ -196,9 +228,7 @@ Adds some rules we generally apply in javascript related repositories.
 
 It includes the following presets:
 
-- the [default config](#default) from this repository
-- [`:pinAllExceptPeerDependencies`](https://docs.renovatebot.com/presets-default/#pinallexceptpeerdependencies)
-- [`:maintainLockFilesMonthly`](https://docs.renovatebot.com/presets-default/#maintainlockfilesmonthly)
+- the [npm-base config](#npm-base) from this repository
 
 and it configures the following:
 
@@ -213,8 +243,6 @@ and it configures the following:
 - Update the `typescript` dependency with higher priority(2) than other dependencies.
   Create separate PRs for patch and minor and multiple minor version upgrades, since they introduce breaking changes in minor versions.
 - Keep the major version of `@types/jest` in sync with the major version of `jest`.
-- group infra as code packages (aws, cdk8s, cdktf, hashicorp) int a single group
-  and schedule their updates during working hours with a priority of 1.
 - Update packages from the `@types/*` scope with lower priority(-5) than other dependencies and disable `npm:unpublishSafe`.
 - link to this section in the readme from the dependency dashboard,
   mentioning that PR might be merged automatically if configured that way.
@@ -227,7 +255,9 @@ A very common thing is to add [`:autoMergePatch`](https://docs.renovatebot.com/p
 
 ### k8s
 
-Extends the [javascript](#javascript) config with additional rules for repositories that manage Kubernetes/CDK8s infrastructure in a `k8s/` directory.
+Adds rules for repositories that manage Kubernetes/CDK8s infrastructure in a `k8s/` directory.
+Use this directly for Python projects with a `k8s/` folder, or use [javascript-k8s](#javascript-k8s)
+for JavaScript/TypeScript projects that also have a `k8s/` folder.
 
 ```json
 {
@@ -239,7 +269,7 @@ Extends the [javascript](#javascript) config with additional rules for repositor
 
 It includes the following presets/configs:
 
-- the [javascript config](#javascript) from this repository
+- the [npm-base config](#npm-base) from this repository
 
 and it configures the following:
 
@@ -251,7 +281,19 @@ and it configures the following:
 - Allow major Node.js version updates in `k8s/.nvmrc` to be created without requiring
   manual approval from the dependency dashboard.
 - Link to this section in the readme from the dependency dashboard,
-  mentioning that this config extends the javascript config and that PRs might be merged automatically.
+  mentioning that PRs might be merged automatically.
+
+### javascript-k8s
+
+Convenience preset for JavaScript/TypeScript repositories that also manage
+Kubernetes/CDK8s infrastructure in a `k8s/` directory. It simply combines the
+[javascript](#javascript) and [k8s](#k8s) presets.
+
+```json
+{
+  "extends": ["github>bettermarks/renovate-config:javascript-k8s"]
+}
+```
 
 ### python
 
@@ -284,4 +326,16 @@ It is very likely (especially for `uv pip compile`, which doesn't include the py
   "constraints": {
     "python": "==3.9"
   },
+```
+
+### python-k8s
+
+Convenience preset for Python repositories that also manage Kubernetes/CDK8s
+infrastructure in a `k8s/` directory. It combines the [python](#python) and
+[k8s](#k8s) presets.
+
+```json
+{
+  "extends": ["github>bettermarks/renovate-config:python-k8s"]
+}
 ```

--- a/init.ts
+++ b/init.ts
@@ -12,6 +12,7 @@ const config = {
   extends: [
     `github>bettermarks/renovate-config${inputs.javascript ? ":javascript" : ""}`,
     inputs.python ? "github>bettermarks/renovate-config:python" : "",
+    inputs.k8s ? "github>bettermarks/renovate-config:k8s" : "",
     inputs.automerge,
   ].filter(Boolean),
 };

--- a/init.ts
+++ b/init.ts
@@ -7,12 +7,24 @@ console.log("process.argv:", JSON.stringify(process.argv));
 const [_nodePath, _scriptPath, target, inputsRaw = "{}"] = process.argv;
 
 const inputs = JSON.parse(inputsRaw);
+
+const preset =
+  inputs.javascript && inputs.k8s
+    ? "javascript-k8s"
+    : inputs.python && inputs.k8s
+      ? "python-k8s"
+      : inputs.javascript
+        ? "javascript"
+        : inputs.python
+          ? "python"
+          : inputs.k8s
+            ? "k8s"
+            : "";
+
 const config = {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    `github>bettermarks/renovate-config${inputs.javascript ? ":javascript" : ""}`,
-    inputs.python ? "github>bettermarks/renovate-config:python" : "",
-    inputs.k8s ? "github>bettermarks/renovate-config:k8s" : "",
+    preset ? `github>bettermarks/renovate-config:${preset}` : "",
     inputs.automerge,
   ].filter(Boolean),
 };

--- a/javascript-k8s.json
+++ b/javascript-k8s.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>bettermarks/renovate-config:javascript",
+    "github>bettermarks/renovate-config:k8s"
+  ],
+  "dependencyDashboardHeader": "Uses https://github.com/bettermarks/renovate-config#javascript-k8s  \nPR that have automerge enabled [might be approved automatically](https://github.com/bettermarks/approve-dependency-pr#readme)"
+}

--- a/javascript.json
+++ b/javascript.json
@@ -59,19 +59,6 @@
       "prPriority": 2
     },
     {
-      "matchSourceUrls": [
-        "https://github.com/aws{/,}**",
-        "https://github.com/cdk8s-team{/,}**",
-        "https://github.com/cdktf{/,}**",
-        "https://github.com/hashicorp{/,}**"
-      ],
-      "groupName": "js infrastructure packages",
-      "prPriority": 1,
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "schedule": ["* 8-12 * * 1"],
-      "automerge": true
-    },
-    {
       "matchManagers": ["npm"],
       "matchPackageNames": ["@types/jest"],
       "versioning": "jest"

--- a/javascript.json
+++ b/javascript.json
@@ -1,12 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>bettermarks/renovate-config",
-    ":pinAllExceptPeerDependencies",
-    ":maintainLockFilesMonthly"
-  ],
+  "extends": ["github>bettermarks/renovate-config:npm-base"],
   "dependencyDashboardHeader": "Uses https://github.com/bettermarks/renovate-config#javascript  \nPR that have automerge enabled [might be approved automatically](https://github.com/bettermarks/approve-dependency-pr#readme)",
-  "npmrc": "@bettermarks:registry=https://npm.pkg.github.com/\n@fortawesome:registry=https://npm.fontawesome.com/\n",
   "packageRules": [
     { "matchUpdateTypes": ["pin"], "prPriority": 10, "automerge": true },
     {
@@ -47,10 +42,6 @@
     {
       "matchSourceUrls": ["https://github.com/Rel1cx/eslint-react"],
       "groupName": "ESLint React"
-    },
-    {
-      "matchSourceUrls": ["https://github.com/prettier/prettier"],
-      "groupName": "Prettier"
     },
     {
       "matchPackageNames": ["typescript"],

--- a/k8s.json
+++ b/k8s.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>bettermarks/javascript"],
+  "dependencyDashboardHeader": "Uses https://github.com/bettermarks/renovate-config#k8s which extends https://github.com/bettermarks/renovate-config#javascript  \nPR that have automerge enabled [might be approved automatically](https://github.com/bettermarks/approve-dependency-pr#readme)",
+  "packageRules": [
+    {
+      "matchSourceUrls": [
+        "https://github.com/aws{/,}**",
+        "https://github.com/cdk8s-team{/,}**",
+        "https://github.com/cdktf{/,}**",
+        "https://github.com/hashicorp{/,}**"
+      ],
+      "groupName": "js infrastructure packages",
+      "prPriority": 1,
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "schedule": ["* 8-12 * * 1"],
+      "automerge": true
+    },
+    {
+      "description": "Dependencies from k8s",
+      "matchFileNames": ["k8s/package.json"],
+      "labels": ["k8s"],
+      "semanticCommitType": "chore",
+      "automerge": true
+    },
+    {
+      "description": "Allow major Node updates in k8s/.nvmrc",
+      "matchManagers": ["nvm"],
+      "matchFileNames": ["k8s/.nvmrc"],
+      "matchUpdateTypes": ["major"],
+      "enabled": true,
+      "dependencyDashboardApproval": false
+    }
+  ]
+}

--- a/k8s.json
+++ b/k8s.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>bettermarks/javascript"],
-  "dependencyDashboardHeader": "Uses https://github.com/bettermarks/renovate-config#k8s which extends https://github.com/bettermarks/renovate-config#javascript  \nPR that have automerge enabled [might be approved automatically](https://github.com/bettermarks/approve-dependency-pr#readme)",
+  "extends": ["github>bettermarks/renovate-config:npm-base"],
+  "dependencyDashboardHeader": "Uses https://github.com/bettermarks/renovate-config#k8s  \nPR that have automerge enabled [might be approved automatically](https://github.com/bettermarks/approve-dependency-pr#readme)",
   "packageRules": [
     {
       "matchSourceUrls": [
@@ -29,7 +29,7 @@
       "matchFileNames": ["k8s/.nvmrc"],
       "matchUpdateTypes": ["major"],
       "enabled": true,
-      "dependencyDashboardApproval": false
+      "dependencyDashboardApproval": true
     }
   ]
 }

--- a/npm-base.json
+++ b/npm-base.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>bettermarks/renovate-config",
+    ":pinAllExceptPeerDependencies",
+    ":maintainLockFilesMonthly"
+  ],
+  "npmrc": "@bettermarks:registry=https://npm.pkg.github.com/\n@fortawesome:registry=https://npm.fontawesome.com/\n",
+  "packageRules": [
+    {
+      "matchSourceUrls": ["https://github.com/prettier/prettier"],
+      "groupName": "Prettier"
+    }
+  ]
+}

--- a/python-k8s.json
+++ b/python-k8s.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>bettermarks/renovate-config:python",
+    "github>bettermarks/renovate-config:k8s"
+  ],
+  "dependencyDashboardHeader": "Uses https://github.com/bettermarks/renovate-config#python-k8s  \nPR that have automerge enabled [might be approved automatically](https://github.com/bettermarks/approve-dependency-pr#readme)"
+}


### PR DESCRIPTION
We want to automatically update node versions of Kubernetes/CDK8s infrastructure in a `k8s/` directory. In the javascript config that was disabled. This PR creates new configs javascript-k8s and python-k8s that additionally contain all neccessary configurations to keep the `k8s/` directory up-to-date.

https://bettermarks.atlassian.net/browse/BM-68739

_Requires adapting projects with `k8s/` directory to use `github>bettermarks/renovate-config:javascript-k8s` or `github>bettermarks/renovate-config:python-k8s`_
