### PR TITLE
chore: add semantic commit scope to differentiate k8s updates

### DIFF
--- a/k8s.json
+++ b/k8s.json
@@ -13,6 +13,7 @@
       "groupName": "js infrastructure packages",
       "prPriority": 1,
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "semanticCommitScope": "k8s",
       "schedule": ["* 8-12 * * 1"],
       "automerge": true
     },
@@ -21,6 +22,7 @@
       "matchFileNames": ["k8s/package.json"],
       "labels": ["k8s"],
       "semanticCommitType": "chore",
+      "semanticCommitScope": "k8s",
       "automerge": true
     },
     {
@@ -28,6 +30,7 @@
       "matchManagers": ["nvm"],
       "matchFileNames": ["k8s/.nvmrc"],
       "matchUpdateTypes": ["major"],
+      "semanticCommitScope": "k8s",
       "enabled": true,
       "dependencyDashboardApproval": true
     }


### PR DESCRIPTION
To be able to differentiate k8s updates on the renovate dashboard in mixed setups we use `chore(k8s)`.

https://bettermarks.atlassian.net/browse/BM-68739
