### PR TITLE
chore: only do major updates in k8s .nvmrc

### DIFF
--- a/k8s.json
+++ b/k8s.json
@@ -33,6 +33,13 @@
       "semanticCommitScope": "k8s",
       "enabled": true,
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Disable non-major Node updates in k8s/.nvmrc",
+      "matchManagers": ["nvm"],
+      "matchFileNames": ["k8s/.nvmrc"],
+      "matchUpdateTypes": ["minor", "patch", "pin"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
We want to keep the behavior we were only pinning major versions in the `k8s/.nvmrc` file.

Should prevent
<img width="2448" height="272" alt="grafik" src="https://github.com/user-attachments/assets/7f4dc0d0-b245-4c9c-b191-79bc72660ba2" />


https://bettermarks.atlassian.net/browse/BM-68739
