### PR TITLE
feat: enable pre-commit manager by default

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,6 +12,9 @@
     "customManagers:githubActionsVersions"
   ],
   "internalChecksFilter": "strict",
+  "pre-commit": {
+    "enabled": true
+  },
   "prConcurrentLimit": 1,
   "prHourlyLimit": 1,
   "updateNotScheduled": false,


### PR DESCRIPTION
## Summary
- Enables Renovate's `pre-commit` manager (`"pre-commit": {"enabled": true}`) in the shared `default.json` config, so every repo extending this preset gets pre-commit hook version updates automatically.

## Why
We rolled out BetterLeaks (secret scanning) via pre-commit across our repos. As a security tool it needs to stay current, but only `bm-backend` currently has this enabled — via a local override in its own `renovate.json`, not through this shared config. The other repos with `.pre-commit-config.yaml` have never had their hook versions updated since initial setup.

This centralizes the setting so:
- Every current repo extending this config picks it up with no per-repo change needed.
- Every future repo gets it by default.

Once this merges, a follow-up PR removes the now-redundant local override from `bm-backend/renovate.json`.