### PR TITLE
fix: run validator from its own checkout, not the consuming repo

### DIFF
--- a/validator/action.yml
+++ b/validator/action.yml
@@ -19,5 +19,13 @@ runs:
 
     - name: validate config file
       # no need to run the ./validate.sh script to check pnpm/node setup, it is faster this way
-      run: pnpm dlx --package renovate renovate-config-validator --strict "${{ inputs.config }}"
+      #
+      # Run from this action's own checkout: `pnpm dlx` reads the
+      # pnpm-workspace.yaml of its working directory, and the consuming
+      # repository may pin a newer pnpm than the one set up above. A repo on
+      # pnpm 11 that sets scoped `registries:` (no implicit `default` in
+      # pnpm 10) makes dlx resolution fail with ERR_INVALID_URL before the
+      # config is ever read.
+      run: pnpm dlx --package renovate renovate-config-validator --strict "$GITHUB_WORKSPACE/${{ inputs.config }}"
       shell: bash
+      working-directory: renovate-config


### PR DESCRIPTION
## Problem

The validator step runs `pnpm dlx` in the **consuming repository's** root, while pnpm is set up from **this** repo's `package.json` (currently `pnpm@10.34.5`). `pnpm dlx` reads the `pnpm-workspace.yaml` of its working directory, so the consuming repo's workspace config gets handed to a pnpm version it was never written for.

This is live today in `bettermarks/universal-component-library`, which is on `pnpm@11.8.0` and declares only scoped registries:

```yaml
registries:
  '@bettermarks': 'https://npm.pkg.github.com/'
  '@fortawesome': 'https://npm.fontawesome.com/'
```

pnpm 11 supplies `registries.default` implicitly; pnpm 10 does not. pnpm 10 then dereferences `undefined` in `getAuthHeaderByURI` and `dlx` dies before the renovate config is ever read:

```
 ERR_INVALID_URL  Invalid URL
pnpm: Invalid URL
    at Object.getAuthHeaderValueByURI (/snapshot/dist/pnpm.cjs)
    at resolveNpm (/snapshot/dist/pnpm.cjs)
    at Object.handler [as dlx] (/snapshot/dist/pnpm.cjs)
```

The check goes red with an error that says nothing about the config it was asked to validate. That workflow only triggers on `paths: [renovate.json]`, so it had not run in that repo since March and the breakage sat unnoticed for months.

## Fix

Run the step from this action's own checkout, whose `pnpm-workspace.yaml` always matches the pnpm set up alongside it, and resolve `inputs.config` against `$GITHUB_WORKSPACE` so it still points at the consuming repo.

This is version-independent — it fixes the current pnpm 10/11 mismatch and any future one, rather than chasing the consuming repos' pnpm versions.

## Verification

Reproduced and fixed locally against the UCL checkout, bisecting `pnpm-workspace.yaml` key by key with pnpm 10.34.5:

| working dir | `pnpm-workspace.yaml` | result |
| --- | --- | --- |
| consuming repo | scoped `registries:` (current) | `getAuthHeaderByURI` crash |
| consuming repo | `configDependencies` only | ok |
| consuming repo | `publicHoistPattern` only | ok |
| consuming repo | `registries:` + explicit `default` | ok |
| this action's checkout (**the fix**) | unchanged UCL workspace | `INFO: Config validated successfully against 1 file(s)` |

The self-test on this PR exercises the changed action (confirmed in the job log: `working directory … /renovate-config`, `--strict "$GITHUB_WORKSPACE/renovate-config/renovate.json"`), and passes.

Note that this only unblocks `universal-component-library` once merged, since consuming repos pin `bettermarks/renovate-config/validator@main`.

## Notes for reviewers

- `validate.sh` has the same latent issue: it also runs `pnpm dlx` in the caller's cwd, and its own comment says it is meant to be invoked from other repositories. Left alone here to keep this focused — could be added to this PR or a follow-up
